### PR TITLE
darwin: drop redundant CFRunLoopObserverInvalidate in teardown

### DIFF
--- a/src/darwin/input_hook.c
+++ b/src/darwin/input_hook.c
@@ -1111,7 +1111,10 @@ static void destroy_main_runloop_info(main_runloop_info **main) {
                  CFRunLoopRemoveObserver(main_loop, (*main)->observer, kCFRunLoopDefaultMode);
              }
 
-             CFRunLoopObserverInvalidate((*main)->observer);
+             // Skip CFRunLoopObserverInvalidate: after CFRunLoopRemoveObserver,
+             // CFRelease alone is sufficient to tear down an owned observer.
+             // The explicit invalidate is redundant and can trigger
+             // __CFCheckCFInfoPACSignature crashes on arm64 macOS.
              CFRelease((*main)->observer);
              (*main)->observer = NULL;
          }
@@ -1246,8 +1249,10 @@ static void destroy_event_runloop_info(event_runloop_info **hook) {
                 CFRunLoopRemoveObserver(event_loop, (*hook)->observer, kCFRunLoopDefaultMode);
             }
 
-            // Invalidate and free hook observer.
-            CFRunLoopObserverInvalidate((*hook)->observer);
+            // Free the hook observer. Previously this also called
+            // CFRunLoopObserverInvalidate, but that is redundant after
+            // CFRunLoopRemoveObserver and can trigger
+            // __CFCheckCFInfoPACSignature crashes on arm64 macOS.
             CFRelease((*hook)->observer);
             (*hook)->observer = NULL;
         }


### PR DESCRIPTION
## Summary

`CFRunLoopObserverInvalidate` is called on the main-runloop and event-runloop observers after they have already been removed via `CFRunLoopRemoveObserver`. On arm64 macOS this occasionally trips `__CFCheckCFInfoPACSignature` and aborts the process with `EXC_BREAKPOINT` / `EXC_ARM_BREAKPOINT` inside `__CFCheckCFInfoPACSignature` during libuiohook teardown (e.g. on application quit).

Per Apple CoreFoundation semantics, `CFRunLoopRemoveObserver` followed by `CFRelease` is sufficient to drop an owned observer; the explicit `CFRunLoopObserverInvalidate` is redundant. Removing it eliminates the PAC check failure without changing observable behavior: the observer is still removed from its runloop and released.

## Safety

The `if (CFRunLoopContainsObserver(...))` guard means `CFRunLoopRemoveObserver` only runs when the observer is actually registered with the queried runloop. The two cases at destroy time:

- **Happy path**: observer was added via `CFRunLoopAddObserver`; `Contains` returns `true`, `Remove` is called, then `Release` deallocates. Unchanged by this patch.
- **Orphan**: observer was created but an early return (e.g. `CFRunLoopSourceCreate` failure in `create_main_runloop_info`) skipped the matching `Add`; `Contains` returns `false`, `Remove` is skipped, `Release` deallocates an observer that was never in any runloop. The old `Invalidate` call was already effectively a no-op in this case beyond flipping the internal valid flag.

Both destroy functions query the same runloop and mode the observer was added in (`CFRunLoopGetMain()` for the main observer, the module-global `event_loop` set once per `hook_run()` for the event observer), so there is no mismatched-runloop case where the observer is live in some other runloop.

## Notes

- The underlying PAC-check failure is arm64-specific, but `CFRunLoopObserverInvalidate` after `CFRunLoopRemoveObserver` is redundant on all Darwin targets, so the patch is a straightforward correctness improvement everywhere.
- Non-Darwin platforms are unaffected.
